### PR TITLE
[Refactor] 불필요한 수량 초기화 로직 삭제

### DIFF
--- a/src/main/java/com/coupop/fcfscoupon/CouponService.java
+++ b/src/main/java/com/coupop/fcfscoupon/CouponService.java
@@ -18,7 +18,6 @@ public class CouponService {
                          final RequestTime requestTime) {
         this.couponCountRepository = couponCountRepository;
         this.requestTime = requestTime;
-        couponCountRepository.setCount(0);
     }
 
     public CouponResponse issue() {


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
매일 쿠폰 지급 수량 초기화 하려고 했으나, redis의 `INCR`사용 시 key 존재하지 않으면 0으로 초기화된 후 실행됨

### Key Changes
<!--주요한 변화들-->

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
Close #8 
