### PR TITLE
fix: Embedded Redis 실행 시 port 사용 여부 정확하게 검증

### DIFF
--- a/src/main/java/com/coupop/fcfscoupon/config/EmbeddedRedisStarter.java
+++ b/src/main/java/com/coupop/fcfscoupon/config/EmbeddedRedisStarter.java
@@ -4,20 +4,26 @@ import jakarta.annotation.PreDestroy;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import redis.embedded.RedisServer;
+
 
 @Component
 public class EmbeddedRedisStarter {
 
     private final RedisServer redisServer;
+    private final Logger logger = LoggerFactory.getLogger(EmbeddedRedisStarter.class);
 
     public EmbeddedRedisStarter(@Value("${spring.data.redis.port}") final int port) throws IOException {
         if (isAvailable(port)) {
             this.redisServer = new RedisServer(port);
             redisServer.start();
+            logger.atInfo().log("Embedded Redis Started");
         } else {
+            logger.atInfo().log("Port Not Available, Embedded Redis Already Started");
             redisServer = null;
         }
     }
@@ -26,6 +32,7 @@ public class EmbeddedRedisStarter {
     public void stopRedis() {
         if (redisServer != null) {
             redisServer.stop();
+            logger.atInfo().log("Embedded Redis Stopped");
         }
     }
 


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
Embedded Redis 실행 시 간헐적으로 port 사용중이 아님에도 사용중이라 판단되어 실행되지 않음

### Key Changes
<!--주요한 변화들-->
포트 검증 시 process 정보를 line별로 받아 각 line에 대해 사용중인 port 정확하게 검증

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
Close #13 