### PR TITLE
chore: embedded mongodb 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,14 +19,20 @@ dependencies {
     // spring data redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // spring data mongodb
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+
     // spring validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // spring mail
     implementation("org.springframework.boot:spring-boot-starter-mail")
 
-    // embedded-redis
+    // embedded redis
     implementation("it.ozimov:embedded-redis:0.7.2")
+
+    // embedded mongodb
+    implementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.6.2")
 
     // rest-assured
     testImplementation("io.rest-assured:rest-assured:5.3.0")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 spring.task.execution.pool.max-size=10
 spring.task.execution.pool.queue-capacity=5
 spring.task.execution.pool.keep-alive=10s
+
+# embedded mongo
+de.flapdoodle.mongodb.embedded.version=5.0.0

--- a/src/test/java/com/coupop/fcfscoupon/infra/EmbeddedMongoDBTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/infra/EmbeddedMongoDBTest.java
@@ -1,0 +1,16 @@
+package com.coupop.fcfscoupon.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@SpringBootTest
+public class EmbeddedMongoDBTest {
+    @Test
+    void example(@Autowired final MongoTemplate mongoTemplate) {
+        assertThat(mongoTemplate.getDb()).isNotNull();
+    }
+}


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
실제 MongoDB 서버 없이도 실행 및 테스트 할 수 있도록 Embedded MongoDB 설정

### Key Changes
<!--주요한 변화들-->
- Embedded MongoDB 및 Spring Data MongoDB boot starter 의존성 추가

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->
[Embedded MongoDB](https://forky-freeky-forky.notion.site/Embedded-MongoDB-a009aab51817482ba095b7600cac5748)

<!--관련 이슈 있을 경우-->
Close #23 
