### PR TITLE
feat: 이메일에 대한 쿠폰 발급 이력 조회 시 발급된 쿠폰 id, 날짜 목록과 OK 응답

### DIFF
--- a/src/main/java/com/coupop/fcfscoupon/CouponController.java
+++ b/src/main/java/com/coupop/fcfscoupon/CouponController.java
@@ -1,5 +1,8 @@
 package com.coupop.fcfscoupon;
 
+import com.coupop.fcfscoupon.coupon.CouponService;
+import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
+import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
 import com.coupop.fcfscoupon.exception.ApiException;
 import com.coupop.fcfscoupon.fcfsissue.FcfsIssueService;
 import com.coupop.fcfscoupon.fcfsissue.dto.IssuanceRequest;
@@ -9,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -18,15 +22,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
     private final FcfsIssueService fcfsIssueService;
+    private final CouponService couponService;
 
-    public CouponController(final FcfsIssueService fcfsIssueService) {
+    public CouponController(final FcfsIssueService fcfsIssueService,
+                            final CouponService couponService) {
         this.fcfsIssueService = fcfsIssueService;
+        this.couponService = couponService;
     }
 
     @PostMapping("/issue")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void issue(@RequestBody @Validated final IssuanceRequest request) {
         fcfsIssueService.issue(request);
+    }
+
+    @GetMapping("/history")
+    @ResponseStatus(HttpStatus.OK)
+    public HistoryResponse findHistoryByEmail(@RequestBody @Validated final HistoryRequest request) {
+        return couponService.findHistoryByEmail(request);
     }
 
     @ExceptionHandler(ApiException.class)

--- a/src/main/java/com/coupop/fcfscoupon/coupon/CouponService.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/CouponService.java
@@ -2,6 +2,7 @@ package com.coupop.fcfscoupon.coupon;
 
 import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
 import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
+import com.coupop.fcfscoupon.coupon.exception.HistoryNotFoundException;
 import com.coupop.fcfscoupon.coupon.model.Coupon;
 import com.coupop.fcfscoupon.coupon.model.CouponEmailSender;
 import com.coupop.fcfscoupon.coupon.model.CouponIssueHistory;
@@ -38,7 +39,11 @@ public class CouponService {
     }
 
     public HistoryResponse findHistoryByEmail(final HistoryRequest request) {
-        CouponIssueHistory history = couponIssueHistoryRepository.findByEmail(request.email());
+        final String email = request.email();
+        final CouponIssueHistory history = couponIssueHistoryRepository.findByEmail(email);
+        if (history == null) {
+            throw new HistoryNotFoundException(email);
+        }
         return HistoryResponse.of(history);
     }
 }

--- a/src/main/java/com/coupop/fcfscoupon/coupon/CouponService.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/CouponService.java
@@ -1,7 +1,10 @@
 package com.coupop.fcfscoupon.coupon;
 
+import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
+import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
 import com.coupop.fcfscoupon.coupon.model.Coupon;
 import com.coupop.fcfscoupon.coupon.model.CouponEmailSender;
+import com.coupop.fcfscoupon.coupon.model.CouponIssueHistory;
 import com.coupop.fcfscoupon.coupon.model.CouponIssueHistoryDetail;
 import com.coupop.fcfscoupon.coupon.model.CouponIssueHistoryRepository;
 import com.coupop.fcfscoupon.coupon.model.CouponRepository;
@@ -32,5 +35,10 @@ public class CouponService {
         couponRepository.save(coupon);
         couponIssueHistoryRepository.save(email, CouponIssueHistoryDetail.ofNew(coupon));
         couponEmailSender.send(coupon, email);
+    }
+
+    public HistoryResponse findHistoryByEmail(final HistoryRequest request) {
+        CouponIssueHistory history = couponIssueHistoryRepository.findByEmail(request.email());
+        return HistoryResponse.of(history);
     }
 }

--- a/src/main/java/com/coupop/fcfscoupon/coupon/dto/HistoryRequest.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/dto/HistoryRequest.java
@@ -1,0 +1,7 @@
+package com.coupop.fcfscoupon.coupon.dto;
+
+import com.coupop.fcfscoupon.support.EmailValidation;
+import jakarta.validation.constraints.Email;
+
+public record HistoryRequest(@Email(regexp = EmailValidation.REGEX, message = EmailValidation.MESSAGE) String email) {
+}

--- a/src/main/java/com/coupop/fcfscoupon/coupon/dto/HistoryResponse.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/dto/HistoryResponse.java
@@ -1,0 +1,14 @@
+package com.coupop.fcfscoupon.coupon.dto;
+
+import com.coupop.fcfscoupon.coupon.model.CouponIssueHistory;
+import java.util.List;
+
+public record HistoryResponse(List<IssuedCouponResponse> issuedCoupons) {
+
+    public static HistoryResponse of(CouponIssueHistory history) {
+        List<IssuedCouponResponse> issuedCoupons = history.getIssuedCoupons().stream()
+                .map(IssuedCouponResponse::of)
+                .toList();
+        return new HistoryResponse(issuedCoupons);
+    }
+}

--- a/src/main/java/com/coupop/fcfscoupon/coupon/dto/IssuedCouponResponse.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/dto/IssuedCouponResponse.java
@@ -1,0 +1,10 @@
+package com.coupop.fcfscoupon.coupon.dto;
+
+import com.coupop.fcfscoupon.coupon.model.CouponIssueHistoryDetail;
+
+public record IssuedCouponResponse(String id, String date) {
+
+    public static IssuedCouponResponse of(CouponIssueHistoryDetail historyDetail) {
+        return new IssuedCouponResponse(historyDetail.getCouponId(), historyDetail.getCreatedAt().toString());
+    }
+}

--- a/src/main/java/com/coupop/fcfscoupon/coupon/exception/HistoryNotFoundException.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/exception/HistoryNotFoundException.java
@@ -1,0 +1,14 @@
+package com.coupop.fcfscoupon.coupon.exception;
+
+import com.coupop.fcfscoupon.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class HistoryNotFoundException extends ApiException {
+
+    private static final String TITLE = "쿠폰 발급 이력이 존재하지 않습니다.";
+    private static final String FORMAT_DETAIL = "이메일 대해 발급된 쿠폰이 존재하지 않습니다. [입력값: %s]";
+
+    public HistoryNotFoundException(final String email) {
+        super(TITLE, String.format(FORMAT_DETAIL, email), HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/coupop/fcfscoupon/coupon/model/CouponIssueHistoryRepository.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/model/CouponIssueHistoryRepository.java
@@ -3,4 +3,6 @@ package com.coupop.fcfscoupon.coupon.model;
 public interface CouponIssueHistoryRepository {
 
     long save(final String email, final CouponIssueHistoryDetail detail);
+
+    CouponIssueHistory findByEmail(String email);
 }

--- a/src/main/java/com/coupop/fcfscoupon/coupon/model/CouponIssueHistoryRepository.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/model/CouponIssueHistoryRepository.java
@@ -4,5 +4,5 @@ public interface CouponIssueHistoryRepository {
 
     long save(final String email, final CouponIssueHistoryDetail detail);
 
-    CouponIssueHistory findByEmail(String email);
+    CouponIssueHistory findByEmail(final String email);
 }

--- a/src/main/java/com/coupop/fcfscoupon/coupon/persistence/MongoCouponIssueHistoryRepository.java
+++ b/src/main/java/com/coupop/fcfscoupon/coupon/persistence/MongoCouponIssueHistoryRepository.java
@@ -28,4 +28,9 @@ public class MongoCouponIssueHistoryRepository implements CouponIssueHistoryRepo
                 .upsert();
         return result.getModifiedCount();
     }
+
+    @Override
+    public CouponIssueHistory findByEmail(final String email) {
+        return mongoTemplate.findOne(query(where("email").is(email)), CouponIssueHistory.class);
+    }
 }

--- a/src/main/java/com/coupop/fcfscoupon/fcfsissue/dto/IssuanceRequest.java
+++ b/src/main/java/com/coupop/fcfscoupon/fcfsissue/dto/IssuanceRequest.java
@@ -1,9 +1,7 @@
 package com.coupop.fcfscoupon.fcfsissue.dto;
 
+import com.coupop.fcfscoupon.support.EmailValidation;
 import jakarta.validation.constraints.Email;
 
-public record IssuanceRequest(@Email(regexp = REGEX_EMAIL, message = MESSAGE_INVALID) String email) {
-
-    private static final String REGEX_EMAIL = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$";
-    private static final String MESSAGE_INVALID = "형식에 맞는 이메일을 입력하세요.";
+public record IssuanceRequest(@Email(regexp = EmailValidation.REGEX, message = EmailValidation.MESSAGE) String email) {
 }

--- a/src/main/java/com/coupop/fcfscoupon/support/EmailValidation.java
+++ b/src/main/java/com/coupop/fcfscoupon/support/EmailValidation.java
@@ -1,0 +1,7 @@
+package com.coupop.fcfscoupon.support;
+
+public class EmailValidation {
+
+    public static final String REGEX = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$";
+    public static final String MESSAGE = "형식에 맞는 이메일을 입력하세요.";
+}

--- a/src/test/java/com/coupop/fcfscoupon/CouponAcceptanceTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/CouponAcceptanceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
@@ -113,7 +114,7 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
                 .body("title", equalTo("쿠폰이 모두 소진되었습니다."));
     }
 
-    @DisplayName("이메일에 대해 쿠폰을 발급받은 날짜를 조회한다.")
+    @DisplayName("이메일에 대해 쿠폰을 발급받은 이력을 조회한다.")
     @Test
     void findHistoryByEmail() {
         // given
@@ -129,6 +130,20 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
         response.statusCode(OK.value())
                 .body("issuedCoupons", hasSize(1))
                 .body("issuedCoupons.date", contains(LocalDate.now().toString()));
+    }
+
+    @DisplayName("이메일에 대해 발급받은 쿠폰이 없을 경우 이력을 조회할 수 없다.")
+    @Test
+    void findHistoryByEmail_ifHistoryNotFound() {
+        // given
+        final HistoryRequest request = new HistoryRequest("foo@bar.com");
+
+        // when
+        ValidatableResponse response = get("/history", request);
+
+        // then
+        response.statusCode(NOT_FOUND.value())
+                .body("title", equalTo("쿠폰 발급 이력이 존재하지 않습니다."));
     }
 
     private ValidatableResponse get(final String url, final Object request) {

--- a/src/test/java/com/coupop/fcfscoupon/CouponAcceptanceTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/CouponAcceptanceTest.java
@@ -1,16 +1,21 @@
 package com.coupop.fcfscoupon;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
 
+import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
 import com.coupop.fcfscoupon.fcfsissue.dto.IssuanceRequest;
 import com.coupop.fcfscoupon.fcfsissue.model.FcfsIssuePolicy;
 import com.coupop.fcfscoupon.testconfig.IntegrationTestConfig;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +44,7 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
         final IssuanceRequest request = new IssuanceRequest("foo@bar.com");
 
         // when
-        final ValidatableResponse response = post(request);
+        final ValidatableResponse response = post("/issue", request);
 
         // then
         response.statusCode(ACCEPTED.value());
@@ -53,7 +58,7 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
         final IssuanceRequest request = new IssuanceRequest(invalidEmail);
 
         // when
-        final ValidatableResponse response = post(request);
+        final ValidatableResponse response = post("/issue", request);
 
         // then
         response.statusCode(BAD_REQUEST.value())
@@ -71,7 +76,7 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
                 .willReturn(closedTime);
 
         // when
-        final ValidatableResponse response = post(request);
+        final ValidatableResponse response = post("/issue", request);
 
         // then
         response.statusCode(BAD_REQUEST.value())
@@ -83,10 +88,10 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
     void issueCoupon_ifCouponUsedToday() {
         // given
         final IssuanceRequest request = new IssuanceRequest("foo@bar.com");
-        post(request);
+        post("/issue", request);
 
         // when
-        final ValidatableResponse response = post(request);
+        final ValidatableResponse response = post("/issue", request);
 
         // then
         response.statusCode(BAD_REQUEST.value())
@@ -98,24 +103,52 @@ public class CouponAcceptanceTest extends IntegrationTestConfig {
     void issueCoupon_ifCouponOutOfStock() {
         // given
         final IssuanceRequest request = new IssuanceRequest("foo@bar.com");
-
         databaseSetUp.setCount(FcfsIssuePolicy.getLimit());
 
         // when
-        final ValidatableResponse response = post(request);
+        final ValidatableResponse response = post("/issue", request);
 
         // then
         response.statusCode(BAD_REQUEST.value())
                 .body("title", equalTo("쿠폰이 모두 소진되었습니다."));
     }
 
-    private ValidatableResponse post(final IssuanceRequest request) {
+    @DisplayName("이메일에 대해 쿠폰을 발급받은 날짜를 조회한다.")
+    @Test
+    void findHistoryByEmail() {
+        // given
+        final String email = "foo@bar.com";
+        post("/issue", new IssuanceRequest(email));
+
+        final HistoryRequest request = new HistoryRequest(email);
+
+        // when
+        ValidatableResponse response = get("/history", request);
+
+        // then
+        response.statusCode(OK.value())
+                .body("issuedCoupons", hasSize(1))
+                .body("issuedCoupons.date", contains(LocalDate.now().toString()));
+    }
+
+    private ValidatableResponse get(final String url, final Object request) {
+        return RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(request)
+                .when()
+                .get(url)
+                .then().log().all();
+    }
+
+    private ValidatableResponse post(final String url, final Object request) {
         return RestAssured
                 .given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when()
-                .post("/issue")
+                .post(url)
                 .then().log().all();
     }
 }

--- a/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
@@ -14,6 +14,7 @@ import com.coupop.fcfscoupon.coupon.CouponService;
 import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
 import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
 import com.coupop.fcfscoupon.coupon.dto.IssuedCouponResponse;
+import com.coupop.fcfscoupon.coupon.exception.HistoryNotFoundException;
 import com.coupop.fcfscoupon.fcfsissue.FcfsIssueService;
 import com.coupop.fcfscoupon.fcfsissue.dto.IssuanceRequest;
 import com.coupop.fcfscoupon.fcfsissue.exception.CouponNotOpenedException;
@@ -152,6 +153,25 @@ class CouponControllerTest {
                 .andExpect(jsonPath("$.issuedCoupons", hasSize(1)))
                 .andExpect(jsonPath("$.issuedCoupons[*].id").value("fakeid"))
                 .andExpect(jsonPath("$.issuedCoupons[*].date").value("2023-05-21"));
+    }
+
+    @DisplayName("이메일에 대한 쿠폰 발급 이력 조회시, 발급 이력이 존재하지 않으면 Not Found 상태를 반환한다.")
+    @Test
+    void findHistoryByEmail_ifHistoryNotFound() throws Exception {
+        // given
+        final String email = "foo@bar.com";
+        final HistoryRequest request = new HistoryRequest(email);
+
+        doThrow(new HistoryNotFoundException(email))
+                .when(couponService).findHistoryByEmail(any(HistoryRequest.class));
+
+        // when
+        final ResultActions resultActions = performGet("/history", request);
+
+        // then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("title").value("쿠폰 발급 이력이 존재하지 않습니다."));
     }
 
     private ResultActions performGet(final String url, final Object request) throws Exception {

--- a/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
@@ -1,18 +1,26 @@
 package com.coupop.fcfscoupon;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.coupop.fcfscoupon.coupon.CouponService;
+import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
+import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
+import com.coupop.fcfscoupon.coupon.dto.IssuedCouponResponse;
 import com.coupop.fcfscoupon.fcfsissue.FcfsIssueService;
 import com.coupop.fcfscoupon.fcfsissue.dto.IssuanceRequest;
 import com.coupop.fcfscoupon.fcfsissue.exception.CouponNotOpenedException;
 import com.coupop.fcfscoupon.fcfsissue.exception.CouponOutOfStockException;
 import com.coupop.fcfscoupon.fcfsissue.exception.EmailAlreadyUsedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +43,9 @@ class CouponControllerTest {
 
     @MockBean
     private FcfsIssueService fcfsIssueService;
+
+    @MockBean
+    private CouponService couponService;
 
     @DisplayName("쿠폰 발행에 성공하면 Accepted 상태를 반환한다.")
     @Test
@@ -119,6 +130,36 @@ class CouponControllerTest {
         resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("title").value("쿠폰이 모두 소진되었습니다."));
+    }
+
+    @DisplayName("이메일에 대한 쿠폰 발급 이력 조회에 성공하면 발급된 쿠폰 목록과 함께 OK 상태를 반환한다.")
+    @Test
+    void findHistoryByEmail() throws Exception {
+        // given
+        final String email = "foo@bar.com";
+        final HistoryRequest request = new HistoryRequest(email);
+        final HistoryResponse response = new HistoryResponse(
+                List.of(new IssuedCouponResponse("fakeid", "2023-05-21")));
+
+        given(couponService.findHistoryByEmail(any(HistoryRequest.class)))
+                .willReturn(response);
+        // when
+        final ResultActions resultActions = performGet("/history", request);
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issuedCoupons", hasSize(1)))
+                .andExpect(jsonPath("$.issuedCoupons[*].id").value("fakeid"))
+                .andExpect(jsonPath("$.issuedCoupons[*].date").value("2023-05-21"));
+    }
+
+    private ResultActions performGet(final String url, final Object request) throws Exception {
+        return mockMvc.perform(get(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
     }
 
     private ResultActions performPost(final String url, final Object request) throws Exception {

--- a/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/CouponControllerTest.java
@@ -36,17 +36,14 @@ class CouponControllerTest {
     @MockBean
     private FcfsIssueService fcfsIssueService;
 
-    @DisplayName("쿠폰 발행에 성공하면 쿠폰 내용과 함께 Accepted 상태를 반환한다.")
+    @DisplayName("쿠폰 발행에 성공하면 Accepted 상태를 반환한다.")
     @Test
     void issue() throws Exception {
         // given
         final IssuanceRequest request = new IssuanceRequest("foo@bar.com");
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/issue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
+        final ResultActions resultActions = performPost("/issue", request);
 
         // then
         resultActions
@@ -61,10 +58,7 @@ class CouponControllerTest {
         final IssuanceRequest request = new IssuanceRequest(invalidEmail);
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/issue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
+        final ResultActions resultActions = performPost("/issue", request);
 
         // then
         resultActions
@@ -83,10 +77,7 @@ class CouponControllerTest {
                 .when(fcfsIssueService).issue(any(IssuanceRequest.class));
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/issue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
+        final ResultActions resultActions = performPost("/issue", request);
 
         // then
         resultActions
@@ -104,10 +95,7 @@ class CouponControllerTest {
                 .when(fcfsIssueService).issue(any(IssuanceRequest.class));
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/issue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
+        final ResultActions resultActions = performPost("/issue", request);
 
         // then
         resultActions
@@ -125,14 +113,18 @@ class CouponControllerTest {
                 .when(fcfsIssueService).issue(any(IssuanceRequest.class));
 
         // when
-        final ResultActions resultActions = mockMvc.perform(post("/issue")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
+        final ResultActions resultActions = performPost("/issue", request);
 
         // then
         resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("title").value("쿠폰이 모두 소진되었습니다."));
+    }
+
+    private ResultActions performPost(final String url, final Object request) throws Exception {
+        return mockMvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/coupop/fcfscoupon/coupon/CouponServiceTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/coupon/CouponServiceTest.java
@@ -8,9 +8,12 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
+import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
+import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
 import com.coupop.fcfscoupon.coupon.model.Coupon;
 import com.coupop.fcfscoupon.coupon.model.CouponIssueHistory;
 import com.coupop.fcfscoupon.testconfig.IntegrationTestConfig;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,5 +48,21 @@ class CouponServiceTest extends IntegrationTestConfig {
                 () -> assertThat(savedHistory).isNotNull(),
                 () -> verify(couponEmailSender).send(any(Coupon.class), eq(email))
         );
+    }
+
+    @DisplayName("이메일로 쿠폰 발급 이력을 조회하여 응답한다.")
+    @Test
+    void findHistoryByEmail() {
+        // given
+        final String email = "yj970125@gmail.com";
+        couponService.createAndSend(1L, email);
+        final HistoryRequest request = new HistoryRequest(email);
+
+        // when
+        final HistoryResponse response = couponService.findHistoryByEmail(request);
+
+        // then
+        assertThat(response.issuedCoupons()).hasSize(1);
+        assertThat(response.issuedCoupons().get(0).date()).isEqualTo(LocalDate.now().toString());
     }
 }

--- a/src/test/java/com/coupop/fcfscoupon/coupon/CouponServiceTest.java
+++ b/src/test/java/com/coupop/fcfscoupon/coupon/CouponServiceTest.java
@@ -1,6 +1,7 @@
 package com.coupop.fcfscoupon.coupon;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,6 +11,7 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 
 import com.coupop.fcfscoupon.coupon.dto.HistoryRequest;
 import com.coupop.fcfscoupon.coupon.dto.HistoryResponse;
+import com.coupop.fcfscoupon.coupon.exception.HistoryNotFoundException;
 import com.coupop.fcfscoupon.coupon.model.Coupon;
 import com.coupop.fcfscoupon.coupon.model.CouponIssueHistory;
 import com.coupop.fcfscoupon.testconfig.IntegrationTestConfig;
@@ -33,7 +35,7 @@ class CouponServiceTest extends IntegrationTestConfig {
     @Test
     void createAndSend() {
         // given
-        final String email = "yj970125@gmail.com";
+        final String email = "foo@bar.com";
 
         // when
         couponService.createAndSend(1L, email);
@@ -54,7 +56,7 @@ class CouponServiceTest extends IntegrationTestConfig {
     @Test
     void findHistoryByEmail() {
         // given
-        final String email = "yj970125@gmail.com";
+        final String email = "foo@bar.com";
         couponService.createAndSend(1L, email);
         final HistoryRequest request = new HistoryRequest(email);
 
@@ -64,5 +66,15 @@ class CouponServiceTest extends IntegrationTestConfig {
         // then
         assertThat(response.issuedCoupons()).hasSize(1);
         assertThat(response.issuedCoupons().get(0).date()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @DisplayName("이메일로 쿠폰 발급 이력을 조회할때 이력이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void findHistoryByEmail_ifHistoryNotFound() {
+        // given
+        final HistoryRequest request = new HistoryRequest("foo@bar.com");
+
+        assertThatExceptionOfType(HistoryNotFoundException.class)
+                .isThrownBy(() -> couponService.findHistoryByEmail(request));
     }
 }


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
이메일에 대해 발급받은 쿠폰의 id와 날짜 목록을 조회한다.
- 쿠폰 발급 이력이 없을 경우 404 Not Found를 응답한다.

### Key Changes
<!--주요한 변화들-->
- 이메일 validation 관련 상수 class로 분리
- MockMVC 호출 구문 method 분리

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
Close #28 
