### PR TITLE
chore: embedded kafka 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ java {
 
 allprojects {
     group = "com.coupop"
-    version = "0.0.1-SNAPSHOT"
+    version = "0.0.3-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/fcfs-coupon-mq/build.gradle.kts
+++ b/fcfs-coupon-mq/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    // spring kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
+    // spring embedded kafka
+    implementation("org.springframework.kafka:spring-kafka-test")
+}

--- a/fcfs-coupon-mq/src/main/java/com/coupop/fcfscoupon/mq/config/EmbeddedKafkaConfig.java
+++ b/fcfs-coupon-mq/src/main/java/com/coupop/fcfscoupon/mq/config/EmbeddedKafkaConfig.java
@@ -1,0 +1,22 @@
+package com.coupop.fcfscoupon.mq.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+
+@Configuration
+public class EmbeddedKafkaConfig {
+
+    @Bean
+    EmbeddedKafkaBroker broker() {
+        return new EmbeddedKafkaBroker(1).kafkaPorts(9092);
+    }
+
+    @Bean
+    NewTopic topic() {
+        return TopicBuilder.name("issueCoupon")
+                .build();
+    }
+}

--- a/fcfs-coupon-mq/src/main/resources/application-mq.properties
+++ b/fcfs-coupon-mq/src/main/resources/application-mq.properties
@@ -1,0 +1,2 @@
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=coupon

--- a/fcfs-coupon-mq/src/test/java/com/coupop/fcfscoupon/mq/TestContext.java
+++ b/fcfs-coupon-mq/src/test/java/com/coupop/fcfscoupon/mq/TestContext.java
@@ -1,0 +1,7 @@
+package com.coupop.fcfscoupon.mq;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestContext {
+}

--- a/fcfs-coupon-mq/src/test/java/com/coupop/fcfscoupon/mq/config/EmbeddedKafkaConfigTest.java
+++ b/fcfs-coupon-mq/src/test/java/com/coupop/fcfscoupon/mq/config/EmbeddedKafkaConfigTest.java
@@ -1,0 +1,34 @@
+package com.coupop.fcfscoupon.mq.config;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(EmbeddedKafkaConfig.class)
+class EmbeddedKafkaConfigTest {
+
+    @DisplayName("Embedded Kafka에 연결할 수 있다.")
+    @Test
+    void connectToEmbeddedKafka() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        final DefaultKafkaProducerFactory<Integer, String> producerFactory
+                = new DefaultKafkaProducerFactory<>(props);
+
+        final KafkaTemplate<Integer, String> kafkaTemplate = new KafkaTemplate<>(producerFactory);
+        assertThatNoException()
+                .isThrownBy(() -> kafkaTemplate.send("issueCoupon", "fakeData"));
+    }
+}

--- a/fcfs-coupon-mq/src/test/resources/application.properties
+++ b/fcfs-coupon-mq/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.default=mq

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "fcfs-coupon"
 include("fcfs-coupon-api")
+include("fcfs-coupon-mq")
 include("fcfs-coupon-domain-fcfs")
 include("fcfs-coupon-domain-coupon")
 include("fcfs-coupon-common")


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
로컬 환경에서 개발 및 실행할 수 있도록 Application 실행 시 Embedded Kafka를 실행하도록 설정한다.

### Key Changes
<!--주요한 변화들-->
fcfs-coupon-mq 모듈 추가
- kafka에 대해 의존적인 message queue 관련 처리 담당

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
Close #37 
