### PR TITLE
chore: Tomcat, Async Thread Pool Graceful Shutdown 설정

### DIFF
--- a/fcfs-coupon-api/src/main/resources/application.properties
+++ b/fcfs-coupon-api/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-spring.profiles.active=coupon,fcfsissue
+spring.profiles.include=coupon,fcfsissue
+
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=20s

--- a/fcfs-coupon-domain-coupon/src/main/resources/application-coupon.properties
+++ b/fcfs-coupon-domain-coupon/src/main/resources/application-coupon.properties
@@ -11,7 +11,7 @@ spring.task.execution.pool.max-size=10
 spring.task.execution.pool.queue-capacity=5
 spring.task.execution.pool.keep-alive=10s
 spring.task.execution.shutdown.await-termination=true
-spring.task.execution.shutdown.await-termination-period=10s
+spring.task.execution.shutdown.await-termination-period=30s
 spring.task.execution.thread-name-prefix=mail-sender-
 
 # embedded mongo

--- a/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/config/AsyncExecutor.java
+++ b/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/config/AsyncExecutor.java
@@ -1,0 +1,19 @@
+package com.coupop.fcfscoupon.domain.coupon.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AsyncExecutor {
+
+    private Logger log = LoggerFactory.getLogger(AsyncExecutor.class);
+
+    @Async
+    public void someJob() throws InterruptedException {
+        log.info("execution start");
+        Thread.sleep(5000);
+        log.info("execution end");
+    }
+}

--- a/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/config/AsyncThreadPoolTest.java
+++ b/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/config/AsyncThreadPoolTest.java
@@ -1,0 +1,23 @@
+package com.coupop.fcfscoupon.domain.coupon.config;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Disabled
+@SpringBootTest
+@Import(AsyncExecutor.class)
+public class AsyncThreadPoolTest {
+
+    @Autowired
+    private AsyncExecutor executor;
+
+    @DisplayName("스프링이 종료될 때 thread pool에 남은 작업이 정상적으로 완료된 후 종료된다.")
+    @Test
+    void gracefullyShutdown_ifSpringContextShutDown() throws InterruptedException {
+        executor.someJob();
+    }
+}

--- a/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/infra/AsyncCouponEmailSenderTest.java
+++ b/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/infra/AsyncCouponEmailSenderTest.java
@@ -1,4 +1,4 @@
-package com.coupop.fcfscoupon.domain.coupon;
+package com.coupop.fcfscoupon.domain.coupon.infra;
 
 import com.coupop.fcfscoupon.domain.coupon.model.Coupon;
 import com.coupop.fcfscoupon.domain.coupon.model.CouponEmailSender;


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
Application을 종료할 때 Tomcat과 Async Thread Pool이 하던 작업을 완료한 후 shutdown되도록 설정한다.

### Key Changes
<!--주요한 변화들-->
메일 발송 비동기 thread pool termination period 10s -> 30s 변경
- 메일 발송 대략 5s * queue size 5 + 여유시간 5s

tomcat server graceful shutdown 설정 추가

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->
[Async Thread Pool Graceful Shutdown 설정](https://forky-freeky-forky.notion.site/Async-Thread-Pool-Graceful-Shutdown-3fa03733edd34839a3166c757eca685d)

<!--관련 이슈 있을 경우-->
Close #39 
