### PR TITLE
test: 쿠폰 수량의 3배 동시 요청에 대해 정확한 수량 발급 검증

### DIFF
--- a/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/TestContext.java
+++ b/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/TestContext.java
@@ -1,4 +1,4 @@
-package com.coupop.fcfscoupon.domain.coupon;
+package com.coupop.fcfscoupon.domain;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/testconfig/DataSetup.java
+++ b/fcfs-coupon-domain-coupon/src/test/java/com/coupop/fcfscoupon/domain/coupon/testconfig/DataSetup.java
@@ -2,6 +2,8 @@ package com.coupop.fcfscoupon.domain.coupon.testconfig;
 
 import com.coupop.fcfscoupon.domain.coupon.model.Coupon;
 import com.coupop.fcfscoupon.domain.coupon.model.CouponRepository;
+import com.coupop.fcfscoupon.domain.history.model.CouponIssueHistory;
+import com.coupop.fcfscoupon.domain.history.model.CouponIssueHistoryRepository;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Component;
 
@@ -10,10 +12,14 @@ public class DataSetup {
 
     private final MongoTemplate mongoTemplate;
     private final CouponRepository couponRepository;
+    private final CouponIssueHistoryRepository historyRepository;
 
-    public DataSetup(final MongoTemplate mongoTemplate, final CouponRepository couponRepository) {
+    public DataSetup(final MongoTemplate mongoTemplate,
+                     final CouponRepository couponRepository,
+                     final CouponIssueHistoryRepository historyRepository) {
         this.mongoTemplate = mongoTemplate;
         this.couponRepository = couponRepository;
+        this.historyRepository = historyRepository;
     }
 
     public void clean() {
@@ -22,9 +28,15 @@ public class DataSetup {
         }
     }
 
-    public String addCoupon() {
+    public Coupon addCoupon() {
         final Coupon coupon = new Coupon("fakeId");
         couponRepository.insert(coupon);
-        return coupon.getId();
+        return coupon;
+    }
+
+    public CouponIssueHistory addHistory(final String couponId, final String email) {
+        final CouponIssueHistory history = CouponIssueHistory.ofNew(email, couponId);
+        historyRepository.save(history);
+        return history;
     }
 }

--- a/fcfs-coupon-domain-fcfs/src/test/java/com/coupop/fcfscoupon/domain/fcfs/FcfsIssueConcurrentTest.java
+++ b/fcfs-coupon-domain-fcfs/src/test/java/com/coupop/fcfscoupon/domain/fcfs/FcfsIssueConcurrentTest.java
@@ -1,0 +1,65 @@
+package com.coupop.fcfscoupon.domain.fcfs;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.coupop.fcfscoupon.client.coupon.CouponService;
+import com.coupop.fcfscoupon.domain.fcfs.exception.CouponOutOfStockException;
+import com.coupop.fcfscoupon.domain.fcfs.model.FcfsIssuePolicy;
+import com.coupop.fcfscoupon.domain.fcfs.testconfig.DataSetup;
+import java.time.LocalTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class FcfsIssueConcurrentTest {
+
+    private static final LocalTime OPENED_TIME = FcfsIssuePolicy.getOpenAt();
+
+    @Autowired
+    private FcfsIssueService fcfsIssueService;
+
+    @Autowired
+    private DataSetup dataSetup;
+
+    @MockBean
+    private CouponService couponService;
+
+    @BeforeEach
+    void setUp() {
+        dataSetup.clean();
+    }
+
+    @DisplayName("100명의 사용자가 동시에 쿠폰 발급을 요청할 때, 정확한 수량만 발급한다.")
+    @Test
+    void issue_concurrent_100() throws InterruptedException {
+        final int numberOfThreads = FcfsIssuePolicy.getLimit() * 3;
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numberOfThreads);
+        final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+
+        final String emailFormat = "foo%d@bar.com";
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int count = i;
+            threadPool.submit(() -> {
+                try {
+                    fcfsIssueService.issue(String.format(emailFormat, count), OPENED_TIME);
+                } catch (CouponOutOfStockException e) {
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        verify(couponService, times(FcfsIssuePolicy.getLimit())).issue(anyLong(), anyString());
+    }
+}

--- a/fcfs-coupon-domain-fcfs/src/test/java/com/coupop/fcfscoupon/domain/fcfs/FcfsIssueServiceTest.java
+++ b/fcfs-coupon-domain-fcfs/src/test/java/com/coupop/fcfscoupon/domain/fcfs/FcfsIssueServiceTest.java
@@ -26,10 +26,10 @@ class FcfsIssueServiceTest {
     private FcfsIssueService fcfsIssueService;
 
     @Autowired
-    protected DataSetup dataSetup;
+    private DataSetup dataSetup;
 
     @MockBean
-    protected CouponService couponService;
+    private CouponService couponService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
쿠폰 발급 수량을 초과하는 요청이 동시에 발생했을 때 정확한 수량만이 발급되는지 검증하는 테스트를 작성한다.

### Key Changes
<!--주요한 변화들-->
- domain-coupon의 service test에서 발급 이력에 대해서도 통합 검증
- domain-fcfs에 동시성 검증 test 추가

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
Close #48 