### PR TITLE
feat(client-coupon): 요청 header 추가, 요청 및 에러 응답 처리 테스트 추가

### DIFF
--- a/fcfs-coupon-client-coupon/build.gradle.kts
+++ b/fcfs-coupon-client-coupon/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
     // mock web server
-    testImplementation("com.squareup.okhttp3:mockwebserver")
+    testImplementation("org.mock-server:mockserver-netty:5.15.0")
 }

--- a/fcfs-coupon-client-coupon/src/main/java/com/coupop/fcfscoupon/client/coupon/CouponWebService.java
+++ b/fcfs-coupon-client-coupon/src/main/java/com/coupop/fcfscoupon/client/coupon/CouponWebService.java
@@ -2,9 +2,12 @@ package com.coupop.fcfscoupon.client.coupon;
 
 import com.coupop.fcfscoupon.api.coupon.dto.IssuanceRequest;
 import com.coupop.fcfscoupon.api.coupon.dto.ResendRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
+@HttpExchange(contentType = MediaType.APPLICATION_JSON_VALUE, accept = MediaType.APPLICATION_JSON_VALUE)
 interface CouponWebService {
 
     @PostExchange("/issue")

--- a/fcfs-coupon-client-coupon/src/test/java/com/coupop/fcfscoupon/client/coupon/CouponServiceTest.java
+++ b/fcfs-coupon-client-coupon/src/test/java/com/coupop/fcfscoupon/client/coupon/CouponServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.MediaType;
 import org.mockserver.verify.VerificationTimes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,6 +47,8 @@ class CouponServiceTest {
                 request()
                         .withMethod("POST")
                         .withPath("/issue")
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withHeader("accept", MediaType.APPLICATION_JSON.toString())
                         .withBody(objectMapper.writeValueAsBytes(new IssuanceRequest(seq, email))),
                 VerificationTimes.once()
         );
@@ -60,6 +63,8 @@ class CouponServiceTest {
                 request()
                         .withMethod("POST")
                         .withPath("/resend")
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withHeader("accept", MediaType.APPLICATION_JSON.toString())
                         .withBody(objectMapper.writeValueAsBytes(new ResendRequest(historyId))),
                 VerificationTimes.once()
         );


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
- client-coupon 요청에 Accept, Content-Type header를 추가한다
- CouponService에서 보내는 요청과 에러 응답에 대한 예외 처리를 정확하게 검증한다

### Key Changes
<!--주요한 변화들-->
서버 mock test tool MockWebServer -> MockServer로 변경
- 수신한 요청에 대해 자세하게 verify, method로 디테일한 응답 mocking

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->
[서버 Mocking으로 Web Client 검증하기](https://forky-freeky-forky.notion.site/Mocking-Web-Client-6119164108de49508222ac05810c524d)

<!--관련 이슈 있을 경우-->
<!--Close #{이슈번호}-->
Close #50 
